### PR TITLE
Split

### DIFF
--- a/app/controllers/bulk_update_controller.rb
+++ b/app/controllers/bulk_update_controller.rb
@@ -2,6 +2,8 @@ class BulkUpdateController < ApplicationController
   include Worthwhile::ThemedLayoutController
   with_themed_layout '1_column'
 
+  authorize_resource class: false
+
   def update
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -18,6 +18,7 @@ class Ability
     can :create, Collection
     can [:destroy], ActiveFedora::Base
     can :manage, Resque
+    can :manage, :bulk_update
   end
 
   private

--- a/app/views/bulk_update/_replace.html.erb
+++ b/app/views/bulk_update/_replace.html.erb
@@ -1,0 +1,22 @@
+<h3> Replace a Subject </h3>
+<p> This form replaces a specified subject field with another field </p>
+<%= form_tag("/bulk_update/replace_subject", action: "update_subject", class: "form-horizontal") do %>
+  <div class="form-group">
+    <%= label_tag( :old, "Old value:", class: "control-label col-sm-2" ) %>
+    <div class="col-sm-10" >
+      <%= text_field_tag( :old, nil, class: "form-control" ) %>
+    </div>
+  </div>
+  <div class="form-group">
+    <%= label_tag(:new, "New value:", class: "control-label col-sm-2" ) %>
+    <div class="col-sm-10">
+      <%= text_field_tag(:new, nil, class: "form-control" ) %>
+    </div>
+  </div>
+  <div class="form-group">
+    <div class="col-sm-offset-2 col-sm-10">
+      <%= submit_tag("Update", class: "btn btn-default btn-primary") %>
+    </div>
+  </div>
+<% end %>
+

--- a/app/views/bulk_update/_split.html.erb
+++ b/app/views/bulk_update/_split.html.erb
@@ -1,0 +1,21 @@
+<h3> Split a Field </h3>
+<p> This form splits a subject into several subjects on a specified character </p>
+<%= form_tag("/bulk_update/split_subject", action: "replace_subject", class: "form-horizontal") do %>
+  <div class="form-group">
+    <%= label_tag( :string, "String to split", class: "control-label col-sm-2") %>
+    <div class="col-sm-10">
+      <%= text_field_tag( :string, nil, class: "form-control" ) %>
+    </div>
+  </div>
+  <div class="form-group">
+    <%= label_tag( :character, "Delimiter", class: "control-label col-sm-2" ) %>
+    <div class="col-sm-10">
+      <%= text_field_tag( :character, nil, class: "form-control" ) %>
+    </div>
+  </div>
+  <div class="form-group">
+    <div class="col-sm-offset-2 col-sm-2">
+      <%= submit_tag("Split", class: "btn btn-default btn-primary" ) %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/bulk_update/index.html.erb
+++ b/app/views/bulk_update/index.html.erb
@@ -1,24 +1,6 @@
 <h1> Bulk Metadata Updates </h1>
 
-<p>This page is used for making bulk changes to individual metadata fields for all works that contain that field.</p>
+<%= render "replace" %>
 
-<h3> Subject </h3>
-<%= form_tag("/bulk_update", action: "update_subject", class: "form-horizontal") do %>
-  <div class="form-group">
-    <%= label_tag( :old, "Old value:", class: "control-label col-sm-2" ) %>
-    <div class="col-sm-10" >
-      <%= text_field_tag( :old, nil, class: "form-control" ) %>
-    </div>
-  </div>
-  <div class="form-group">
-    <%= label_tag(:new, "New value:", class: "control-label col-sm-2" ) %>
-    <div class="col-sm-10">
-      <%= text_field_tag(:new, nil, class: "form-control" ) %>
-    </div>
-  </div>
-  <div class="form-group">
-    <div class="col-sm-offset-2 col-sm-10">
-      <%= submit_tag("Update", class: "btn btn-default btn-primary") %>
-    </div>
-  </div>
-<% end %>
+<%= render "split" %>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Absolute::Application.routes.draw do
   resource :admin_menu, only: :show, controller: 'admin_menu'
   match 'catalog/export_ris/:id', to: 'catalog#export_ris', via: [:get, :post]
 
-  post '/bulk_update', to: 'bulk_update#replace_subject'
+  post '/bulk_update/replace_subject', to: 'bulk_update#replace_subject'
+  post '/bulk_update/split_subject', to: 'bulk_update#split_subject'
   get '/bulk_update', to: 'bulk_update#index'
 end


### PR DESCRIPTION
This update adds security to the bulk update feature so that only admins can access the page. It also adds the ability for a user to enter a facet and a delimiter character that will split the original subject field on that character and create a dc:subject field for each of the separated components.