### PR TITLE
Subject facet now sorts in alphabetical order regardless of case.

### DIFF
--- a/app/controllers/bulk_update_controller.rb
+++ b/app/controllers/bulk_update_controller.rb
@@ -1,19 +1,11 @@
 class BulkUpdateController < ApplicationController
   include Worthwhile::ThemedLayoutController
+  include ApplicationHelper
   with_themed_layout '1_column'
 
   authorize_resource class: false
 
   def update
-  end
-
-  # Create a connection to the local solr server
-  def remote_solr
-    return @remote_solr if @remote_solr
-    solr_config_file = Rails.root.join('config', 'solr.yml')
-    config_erb = ERB.new(IO.read(solr_config_file)).result(binding)
-    location = Psych.load(config_erb)[Rails.env]
-    @remote_solr = RSolr.connect( url: location['url'] )
   end
 
   # Get the PIDs for a specified search

--- a/app/controllers/concerns/worthwhile/catalog_controller.rb
+++ b/app/controllers/concerns/worthwhile/catalog_controller.rb
@@ -40,7 +40,7 @@ module Worthwhile::CatalogController
       config.add_facet_field solr_name("human_readable_type", :facetable)
       config.add_facet_field solr_name('desc_metadata__creator', :facetable), limit: 5, sort: 'index'
       config.add_facet_field solr_name("desc_metadata__tag", :facetable), limit: 5, sort: 'index'
-      config.add_facet_field solr_name("desc_metadata__subject", :facetable), limit: 5, sort: 'index'
+      config.add_facet_field "subject_sort", label:'Subject', limit: 5, sort: 'index', helper_method: :find_case
       config.add_facet_field solr_name("desc_metadata__language", :facetable), limit: 5, sort: 'index'
       config.add_facet_field solr_name("desc_metadata__based_near", :facetable), limit: 5, sort: 'index'
       config.add_facet_field solr_name("file_format", :facetable), limit: 5

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,4 +32,13 @@ module ApplicationHelper
     markup.html_safe
   end
 
+  # Create a connection to the local solr server
+  def remote_solr
+    return @remote_solr if @remote_solr
+    solr_config_file = Rails.root.join('config', 'solr.yml')
+    config_erb = ERB.new(IO.read(solr_config_file)).result(binding)
+    location = Psych.load(config_erb)[Rails.env]
+    @remote_solr = RSolr.connect( url: location['url'] )
+  end
+
 end

--- a/app/helpers/facet_helper.rb
+++ b/app/helpers/facet_helper.rb
@@ -17,6 +17,15 @@ module FacetHelper
     super
   end
 
+  # Helper method to display correct case of subject facets.
+  # Queries given an all lower case facet, queries solr for the correctly cased one and displays that.
+  def find_case(value)
+    query = remote_solr.get('select', params: {q: "subject_sort:\"#{value}\"", fl: 'desc_metadata__subject_tesim', rows: 1})
+    subjects =  query['response']['docs'][0]['desc_metadata__subject_tesim']
+    subject = subjects.select { |s| s.downcase.include? value}
+    value = subject[0]
+  end
+
   # A helper method so that Blacklight will display a link to the source if
   # if it is a valid url. Can be used as a substitued to Worthwile's
   # curation_concern_attribute_to_html

--- a/solr_conf/conf/schema.xml
+++ b/solr_conf/conf/schema.xml
@@ -13,6 +13,9 @@
     <field name="lat" type="tdouble" stored="true" indexed="true" multiValued="false"/>
     <field name="lng" type="tdouble" stored="true" indexed="true" multiValued="false"/>
 
+    <!-- To hold the lowercased subjects for sorting purposes -->
+    <field name="subject_sort" type="alphaSort" stored="false" indexed="true" multiValued="true"/>
+
     <!-- NOTE:  not all possible Solr field types are represented in the dynamic fields -->
 
     <!-- text (_t...) -->
@@ -149,9 +152,9 @@
     <!-- you must define copyField source and dest fields explicity or schemaBrowser doesn't work -->
     <field name="all_text_timv" type="text" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
 
-
   </fields>
 
+  <copyField source="desc_metadata__subject_sim" dest="subject_sort"/>
 
   <!-- Above, multiple source fields are copied to the [text] field.
       Another way to map multiple source fields to the same

--- a/spec/helpers/facet_helper_spec.rb
+++ b/spec/helpers/facet_helper_spec.rb
@@ -40,11 +40,25 @@ describe FacetHelper do
     end
 
   end
+
+  describe '#find_case' do
+    context 'when subject is uppercase' do
+      subject { helper.find_case('never') }
+      it { should eq "Never" }
+    end
+    context 'when subject is lowercase' do
+      subject {helper.find_case('gonna') }
+      it { should eq 'gonna' }
+    end
+    before do
+      GenericWork.create!(pid: "rick:123", title: ["Let's Roll"], subject: ["Never", "gonna", "give", "you", "Up"])
+    end
+  end
   
   describe '#curation_concern_with_link_to_html' do
     context 'when field not a valid url' do
       let(:regular_source) { GenericWork.create!(pid: "me:123", title: ["Just a Test"], source: ["National Geographic"]) }
-      subject { helper.curation_concern_with_link_to_html(regular_source, :source, "Source") }
+      subject {helper.curation_concern_with_link_to_html(regular_source, :source, "Source") }
       it { should eq "<tr><th>Source</th>\n<td><ul class='tabular'><li class=\"attribute source\"> National Geographic </li>\n</ul></td></tr>"}
     end
 


### PR DESCRIPTION
This fixes the issue of sorting the subject facet in alphabetical order. Blacklight's alphabetical sort does so by ASCII value, so all lowercase values are put after all uppercase fields. (e.g. dog would come after Zebra). This restriction from Blacklight probably comes from the fact Solr will only sort facets alphabetically like that or by count. I couldn't find a way to get Solr to return facet values in any way but those 2 sorts. Loading all the data in from Solr and sorting in Ruby was not a viable option because the query results would be too large and impact performance.

To solve the problem, a new field called subject_sort was created in Solr and set up to hold the subject data run through a filter that cleaned up and lowercased the values. This was the field used by Blacklight to create the facets. Since everything was lowercased, case no longer mattered. A helper method was added to the Blacklight facet to get the display value from the lowercased version. The helper method takes the lowercased subject and queries Solr for a document who's subject_sort field has a matching value. It returns it's desc_metadata__subject_tesim field (the original subject values without the case changed) which is multivalued, so we do a case insensitive search through the array to find the matching value then return that for display. Because all subjects should have the same case (e.g. mRNA will be lowercase to start while "normal" words like Yeast will be uppercase), it doesn't matter which document's subjects the query returned when we use them to find the case.

One more little change, the BulkUpdateController had a method to retrieve the appropriate remote Solr instance. Because this was used to get the Solr instance when querying for the correct case, I moved it to ApplicationHelper so it could be used throughout the project.