### PR TITLE
Create a button that updates identifiers to handle.net links

### DIFF
--- a/app/controllers/bulk_update_controller.rb
+++ b/app/controllers/bulk_update_controller.rb
@@ -10,7 +10,7 @@ class BulkUpdateController < ApplicationController
 
   # Get the PIDs for a specified search
   def get_pids(query)
-    response = remote_solr.get('select', params: { q: query, fl: "id", rows: 1000 } )
+    response = remote_solr.get('select', params: { q: query, fl: "id", rows: 100000 } )
     pids = response['response']['docs']
   end
 
@@ -59,6 +59,31 @@ class BulkUpdateController < ApplicationController
         item.update_index
       end
     end
+    redirect_to bulk_update_path
+  end
+
+  # This function updates each identifier that is not a doi or a handle to be a handle.net link
+  def update_identifier
+    get_pids("desc_metadata__identifier_tesim:* -active_fedora_model_ssi:Worthwhile*").each do |pid|
+      item = ActiveFedora::Base.find(pid['id'])
+      ids = []
+      item.identifier.each do |identifier|
+        if identifier[0..20] == 'http://hdl.handle.net'
+          ids << identifier
+        end
+
+        if identifier[0..3] == 'ksl:'
+          ids << "http://hdl.handle.net/2186/#{identifier}"
+        end
+        
+        if identifier[0..2] == "DOI"
+          ids << identifier
+        end
+      end
+      item.identifier = ids unless ids.nil? or ids.empty?
+      item.save unless ids.nil? or ids.empty?
+      item.update_index unless ids.nil? or ids.empty?
+    end 
     redirect_to bulk_update_path
   end
 

--- a/app/views/bulk_update/_identifier.html.erb
+++ b/app/views/bulk_update/_identifier.html.erb
@@ -1,0 +1,8 @@
+<h3> Update Identifiers </h3>
+<p> This button will update all identifiers from pids to handle links, leaving DOI (in the format "DOI: xxxxx")
+references alone. It processes each item, so it will take a long time to complete.
+<%= form_tag '/bulk_update/update_identifier', class: "form-horizontal" do %>
+  <div class="form-group">
+    <%= submit_tag "Update Identifiers", data: {confirm: "This will take a long time. Are you sure?"}, class: "btn btn-default btn-primary" %>
+  </div>
+<% end %>

--- a/app/views/bulk_update/index.html.erb
+++ b/app/views/bulk_update/index.html.erb
@@ -3,3 +3,5 @@
 <%= render "replace" %>
 
 <%= render "split" %>
+
+<%= render "identifier" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,5 +25,6 @@ Absolute::Application.routes.draw do
 
   post '/bulk_update/split', to: 'bulk_update#split'
   post '/bulk_update/replace', to: 'bulk_update#replace'
+  post '/bulk_update/update_identifier', to: 'bulk_update#update_identifier'
   get '/bulk_update', to: 'bulk_update#index'
 end


### PR DESCRIPTION
This creates a button that gets all items from fedora that are not a `Worthwhile::GenericFile` or a `Worthwhile::LinkedResource` and have an identifier. Each identifier is examined so that only DOIs that are in the form `DOI: xxxxxxxx` and handle.net links are in the identifier field. PIDs that are in the identifier field are replaced with their corresponding handle link.