### PR TITLE
Embed youtube links that are attached to video content

### DIFF
--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -3,4 +3,9 @@ class Video < ActiveFedora::Base
 
   self.human_readable_short_description = "Any Video work, preferably with PBCore xml attached."
   self.accept_datastream_attachments ["PBCore","MODS","QDC"]
+
+  def youtube?
+     self.linked_resources.map(&:url).any? { |link| link.include?("youtube.com") }
+  end
+
 end

--- a/app/views/curation_concern/videos/_representative_media.html.erb
+++ b/app/views/curation_concern/videos/_representative_media.html.erb
@@ -1,0 +1,10 @@
+<% if work.youtube? %>
+  <% work.linked_resources.each do |link| %>
+    <% if link.url.include?("youtube.com") %>
+      <% embed_link = URI(link.url) %>
+      <iframe width="480" height="360" src="http://www.youtube.com/embed/<%= embed_link.query.sub!("v=","") %>" frameborder="0" allowfullscreen></iframe>
+    <% end %>
+  <% end %>
+<% else %>
+  <%= render partial: 'curation_concern/base/representative_media', locals: { work: work } %>
+<% end %>

--- a/lib/import/object_factory.rb
+++ b/lib/import/object_factory.rb
@@ -56,7 +56,7 @@ class ObjectFactory
   def object_class
     if collection?
       Collection
-    elsif video?
+    elsif video? or has_links_to_video?
       Video
     elsif audio?
       Audio
@@ -144,6 +144,15 @@ class ObjectFactory
       has_matching_dsid = special_dsids.map(&:downcase).include?(dsid.downcase)
       ds = @source_object.datastreams[dsid]
       has_matching_dsid && (ds.external? || ds.redirect?)
+    }
+  end
+
+  # Load items that have a link to youtube as video instead of text
+  def has_links_to_video?
+    @source_object.datastreams.keys.any?{ |dsid|
+      has_link_dsid = ["link"].map(&:downcase).include?(dsid.downcase)
+      ds = @source_object.datastreams[dsid]
+      has_link_dsid && (ds.dsLocation.include? "youtube.com")
     }
   end
 


### PR DESCRIPTION
When there is a Youtube link in an item it is loaded as a video instead of a text. These items then embed the youtube video in the page. The assumption about youtube links is that they are in the form youtube.com/watch/v=xxxxxxxxx containing a video ID.